### PR TITLE
Fix `StringArrayCallback` Parameters

### DIFF
--- a/src/main/java/org/team199/wpiws/interfaces/StringArrayCallback.java
+++ b/src/main/java/org/team199/wpiws/interfaces/StringArrayCallback.java
@@ -11,6 +11,6 @@ public interface StringArrayCallback {
      * @param name the device identifier of the device calling the callback
      * @param value the String data values
      */
-    public void callback(String name, String value);
+    public void callback(String name, String[] value);
 
 }


### PR DESCRIPTION
A minor change to fix the parameter types of `StringArrayCallback`. This class appears to be unused at the moment, so it shouldn't impact existing functionality, but it may become relevant in later versions of the Robot Interface Specification.