### PR TITLE
Make VSCode use wpilib java formatting.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.format.settings.url": "https://raw.githubusercontent.com/wpilibsuite/styleguide/main/ide/eclipse-java-google-style.xml",
+    "editor.formatOnSaveMode": "modificationsIfAvailable"
 }


### PR DESCRIPTION
Also ensures that if you have enabled format on save, it only formats the modified lines.