### PR TITLE
Enable Caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ task archiveTemplate(type: Tar) {
         into "asyncapi-template" // npm requires that everything be in a top-level folder
     }
 
+    System.out.
+
     // Allow the outputs of this task to be cached
     outputs.cacheIf { true }
 }
@@ -77,17 +79,17 @@ task cleanDeviceFiles(type: Delete) {
 
 // Use a version of node and npm that is known to work.
 node {
-  download = true
-  version = '20.12.2'
-  npmVersion = '10.5.0'
+    download = true
+    version = '20.12.2'
+    npmVersion = '10.5.0'
 }
 
 publishing {
-  publications {
-    maven(MavenPublication) {
-      groupId = 'org.carlmontrobotics'
-      artifactId = 'WPIWebSockets'
-      from components.java
+    publications {
+        maven(MavenPublication) {
+            groupId = 'org.carlmontrobotics'
+            artifactId = 'WPIWebSockets'
+            from components.java
+        }
     }
-  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ task generateDeviceFiles(type: NpxTask) {
     outputs.dir(outputDir).withPropertyName("outputDir")
 
     // Allow the outputs of this task to be cached
-    task.outputs.cacheIf { true }
+    outputs.cacheIf { true }
 }
 
 // Include the generated files in the source to compile.

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ task generateDeviceFiles(type: NpxTask) {
     // when necessary.
     inputs.files(archiveTemplate.outputs)
     outputs.dir(outputDir).withPropertyName("outputDir")
+
+    // Allow the outputs of this task to be cached
+    task.outputs.cacheIf { true }
 }
 
 // Include the generated files in the source to compile.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ task archiveTemplate(type: Tar) {
         exclude "node_modules"
         into "asyncapi-template" // npm requires that everything be in a top-level folder
     }
+
+    // Allow the outputs of this task to be cached
+    outputs.cacheIf { true }
 }
 
 // Add a task to generate java source code for the devices using npx to run

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,6 @@ task archiveTemplate(type: Tar) {
         into "asyncapi-template" // npm requires that everything be in a top-level folder
     }
 
-    System.out.
-
     // Allow the outputs of this task to be cached
     outputs.cacheIf { true }
 }


### PR DESCRIPTION
Enables the build cache for the `archiveTemplate` and `generateDeviceFiles` tasks. For use with DeepBlueRobotics/DeepBlueSim#68.