### PR TITLE
Only Import `wpiws.types.*` When Necessary

### DIFF
--- a/asyncapi-template/filters/PropertyFilter.js
+++ b/asyncapi-template/filters/PropertyFilter.js
@@ -112,4 +112,22 @@ function isRobotOutput(prop) {
     return prop.startsWith("<");
 }
 
-module.exports = { formatPropName, cap1, formatPropType, formatPropObjType, formatPropCallbackType, formatPropParser, formatPropInitialValue, isRobotInput, isRobotOutput }
+function usesCustomTypes(props, schemaName) {
+    for (const [propName, prop] of Object.entries(props)) {
+        if (formatPropParser(prop, schemaName, propName) !== "null") return true;
+    }
+    return false;
+}
+
+module.exports = {
+    formatPropName,
+    cap1,
+    formatPropType,
+    formatPropObjType,
+    formatPropCallbackType,
+    formatPropParser,
+    formatPropInitialValue,
+    isRobotInput,
+    isRobotOutput,
+    usesCustomTypes
+}

--- a/asyncapi-template/template/$$schema$$.java
+++ b/asyncapi-template/template/$$schema$$.java
@@ -35,7 +35,9 @@ import org.team199.wpiws.StateDevice;
 import org.team199.wpiws.connection.ConnectionProcessor;
 import org.team199.wpiws.connection.WSValue;
 import org.team199.wpiws.interfaces.*;
+{%- if (props | usesCustomTypes(name)) %}
 import org.team199.wpiws.types.*;
+{%- endif %}
 
 /**
  * Represents a simulated {{ name | lower }}


### PR DESCRIPTION
Fixes warnings caused by the unnecessary import `import org.team199.wpiws.types.*;` in some device files.