### PR TITLE
Update WebSockets Spec

### DIFF
--- a/asyncapi-template/filters/DeviceFilter.js
+++ b/asyncapi-template/filters/DeviceFilter.js
@@ -26,7 +26,11 @@ function formatName(type) {
         case "AI":
             return "AnalogInput";
         case "AO":
-            return "AnalogOutput"
+            return "AnalogOutput";
+        case "CANAccel":
+            return "CANAccelerometer";
+        case "CANAIn":
+            return "CANAnalogInput";
         case "CTREPCM":
             return "PCM";
         default:

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ task generateDeviceFiles(type: NpxTask) {
     command = '@asyncapi/generator@1.17.25'
     args = ['--force-write',
         '-o', "${outputDir}/org/team199/wpiws/devices",
-        "https://raw.githubusercontent.com/wpilibsuite/allwpilib/3b8d8a367b49bea28d5423dca53f913c13ff6936/simulation/halsim_ws_core/doc/wpilib-ws.yaml",
+        "https://raw.githubusercontent.com/DeepBlueRobotics/allwpilib/5e85b83d920d78a1ec6b1e1919ddcbeece7d25e1/simulation/halsim_ws_core/doc/wpilib-ws.yaml",
         file(archiveTemplate.archiveFile).toURI()]
 
     // Define the inputs and outputs of this task so that gradle only runs it

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ task generateDeviceFiles(type: NpxTask) {
     command = '@asyncapi/generator@1.17.25'
     args = ['--force-write',
         '-o', "${outputDir}/org/team199/wpiws/devices",
-        "https://raw.githubusercontent.com/DeepBlueRobotics/allwpilib/5e85b83d920d78a1ec6b1e1919ddcbeece7d25e1/simulation/halsim_ws_core/doc/wpilib-ws.yaml",
+        "https://raw.githubusercontent.com/DeepBlueRobotics/allwpilib/c1fc86033a4b5ebda451de657fc2546eb3f431fb/simulation/halsim_ws_core/doc/wpilib-ws.yaml",
         file(archiveTemplate.archiveFile).toURI()]
 
     // Define the inputs and outputs of this task so that gradle only runs it


### PR DESCRIPTION
Makes the necessary changes to update to the latest version of the spec. Note: As a result of the new spec, `CAN*` devices are no longer aliased to their non-can counterparts. Personally, I'm fine with this, but we can think about ways to bring back this behavior if you feel that it's important. Despite this, however, I left the code supporting alternate types in `$schema$.java`. I don't see any harm to keeping it around, and it could be useful if we ever want to do something similar in the future.

At the moment, `build.gradle` points to a PR'd version of the spec. This PR should not be merged until wpilibsuite/allwpilib#6679 is merged and `build.gradle` is updated to point at the WPILib commit.